### PR TITLE
Add support to maven shaded plugin to avoid conflicts with existing spring boot projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.project
+integration-api-java-sdk/dependency-reduced-pom.xml

--- a/integration-api-java-sdk/pom.xml
+++ b/integration-api-java-sdk/pom.xml
@@ -230,7 +230,7 @@
                     </execution>
                   </executions>
                 </plugin>
-                <plugin>
+<!--                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-javadoc-plugin</artifactId>
                   <version>3.2.0</version>
@@ -242,7 +242,8 @@
                       </goals>
                     </execution>
                   </executions>
-                </plugin>
+                </plugin>-->
+<!--
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-gpg-plugin</artifactId>
@@ -256,6 +257,56 @@
                       </goals>
                     </execution>
                   </executions>
+                </plugin>
+-->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.1.1</version>
+                    <configuration>
+                        <descriptorRefs>
+                            <descriptorRef>jar-with-dependencies</descriptorRef>
+                        </descriptorRefs>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>make-assembly</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>single</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.2.4</version>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
+                            <configuration>
+                                <relocations>
+                                    <relocation>
+                                        <pattern>org.springframework</pattern>
+                                        <shadedPattern>org.springframework.shaded</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>com.fasterxml</pattern>
+                                        <shadedPattern>com.fasterxml.shaded</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>org.apache</pattern>
+                                        <shadedPattern>org.apache.shaded</shadedPattern>
+                                    </relocation>
+                                </relocations>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         <!-- </pluginManagement> -->


### PR DESCRIPTION
This PR reallocate the following packages in order to avoid compatibility issues with spring boot projects:
- org.springframework -> org.springframework.shaded
- com.fasterxml -> com.fasterxml.shaded
- org.apache -> org.apache.shaded